### PR TITLE
Fix using multiple connections simultaneously 

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -111,6 +111,21 @@ module.exports = (function () {
       return cb();
     },
 
+    /**
+     * Ensures that the given connection is connected with the marshalled configuration.
+     * @param {String} connection
+     * @param {Function} cb
+     */
+    connectConnection: function(connection, cb){
+      if (!connections[connection].mssqlConnection) {
+        connections[connection].mssqlConnection = new mssql.Connection(marshalConfig(connections[connection].config));
+        connections[connection].mssqlConnection.connect(cb)
+      }
+      else {
+        _.defer(cb);
+      }
+    },
+
 
     /**
      * Fired when a model is unregistered, typically when the server
@@ -140,13 +155,13 @@ module.exports = (function () {
 			// Add in logic here to describe a collection (e.g. DESCRIBE TABLE logic)
       var tableName = collection;
       var statement = "SELECT c.name AS ColumnName,TYPE_NAME(c.user_type_id) AS TypeName,c.is_nullable AS Nullable,c.is_identity AS AutoIncrement,ISNULL((SELECT is_unique FROM sys.indexes i LEFT OUTER JOIN sys.index_columns ic ON i.index_id=ic.index_id WHERE i.object_id=t.object_id AND ic.object_id=t.object_id AND ic.column_id=c.column_id),0) AS [Unique],ISNULL((SELECT is_primary_key FROM sys.indexes i LEFT OUTER JOIN sys.index_columns ic ON i.index_id=ic.index_id WHERE i.object_id=t.object_id AND ic.object_id=t.object_id AND ic.column_id=c.column_id),0) AS PrimaryKey,ISNULL((SELECT COUNT(*) FROM sys.indexes i LEFT OUTER JOIN sys.index_columns ic ON i.index_id=ic.index_id WHERE i.object_id=t.object_id AND ic.object_id=t.object_id AND ic.column_id=c.column_id),0) AS Indexed FROM sys.tables t INNER JOIN sys.columns c ON c.object_id=t.object_id LEFT OUTER JOIN sys.index_columns ic ON ic.object_id=t.object_id WHERE t.name='" + tableName + "'";
-      mssql.connect(marshalConfig(connections[connection].config), function __DESCRIBE__(err) {
+      adapter.connectConnection(connection, function __DESCRIBE__(err) {
         if (err) {
           console.error(err);
           return cb(err);
         }
 
-        var request = new mssql.Request();
+        var request = new mssql.Request(connections[connection].mssqlConnection);
         request.query(statement, function(err, recordset) {
           if (err) return cb(err);
           if (recordset.length === 0) return cb();
@@ -165,7 +180,7 @@ module.exports = (function () {
      */
     define: function (connection, collection, definition, cb) {
 			// Add in logic here to create a collection (e.g. CREATE TABLE logic)
-      mssql.connect(marshalConfig(connections[connection].config), function __DEFINE__(err) {
+      adapter.connectConnection(connection, function __DEFINE__(err) {
         if (err) {
           console.error(err);
           return cb(err);
@@ -173,7 +188,7 @@ module.exports = (function () {
         var schema = sql.schema(collection, definition);
         var statement = 'CREATE TABLE [' + collection + '] (' + schema + ')';
 
-        var request = new mssql.Request();
+        var request = new mssql.Request(connections[connection].mssqlConnection);
         request.query(statement, function(err, recordset) {
           if (err) return cb(err);
           cb(null, {});
@@ -189,21 +204,19 @@ module.exports = (function () {
      *
      */
     drop: function (connection, collection, relations, cb) {
-
-			// Add in logic here to delete a collection (e.g. DROP TABLE logic)
-			var statement = 'IF OBJECT_ID(\'dbo.'+ collection + '\', \'U\') IS NOT NULL DROP TABLE [' + collection + ']';
-			mssql.connect(marshalConfig(connections[connection].config), function __DROP__(err) {
+      // Add in logic here to delete a collection (e.g. DROP TABLE logic)
+      var statement = 'IF OBJECT_ID(\'dbo.'+ collection + '\', \'U\') IS NOT NULL DROP TABLE [' + collection + ']';
+      adapter.connectConnection(connection, function __DROP__(err) {
         if (err) {
           console.error(err);
           return cb(err);
         }
-
-				var request = new mssql.Request();
-				request.query(statement, function(err) {
-					if (err) return cb(err);
-					cb(null, {});
-				});
-			});
+        var request = new mssql.Request(connections[connection].mssqlConnection);
+        request.query(statement, function(err) {
+            if (err) return cb(err);
+            cb(null, {});
+        });
+      });
     },
 
     /**
@@ -226,13 +239,13 @@ module.exports = (function () {
 
       options.__primaryKey__ = adapter.getPrimaryKey(connection, collection);
       var statement = sql.selectQuery(collection, options);
-      mssql.connect(marshalConfig(connections[connection].config), function __FIND__(err) {
+      adapter.connectConnection(connection, function __FIND__(err) {
         if (err) {
           console.error(err);
           return cb(err);
         }
 
-        var request = new mssql.Request();
+        var request = new mssql.Request(connections[connection].mssqlConnection);
         //console.log('find:', statement);
         request.query(statement, function(err, recordset) {
 
@@ -250,13 +263,13 @@ module.exports = (function () {
         data = null;
       }
 
-     	mssql.connect(marshalConfig(connections[connection].config), function __FIND__(err) {
+        adapter.connectConnection(connection, function __FIND__(err) {
         if (err) {
           console.error(err);
           return cb(err);
         }
 
-        var request = new mssql.Request();
+        var request = new mssql.Request(connections[connection].mssqlConnection);
         request.query(query, function(err, recordset) {
           if (err) return cb(err);
           cb(null, recordset);
@@ -285,13 +298,13 @@ module.exports = (function () {
 
       //console.log('create statement:', statement);
 
-      mssql.connect(marshalConfig(connections[connection].config), function __CREATE__(err) {
+      adapter.connectConnection(connection, function __CREATE__(err) {
         if (err) {
           console.error(err);
           return cb(err);
         }
 
-        var request = new mssql.Request();
+        var request = new mssql.Request(connections[connection].mssqlConnection);
         request.query(statement, function(err, recordsets) {
           if (err) {
             console.error(err);
@@ -330,13 +343,13 @@ module.exports = (function () {
       var pk = adapter.getPrimaryKey(connection, collection);
 
       var statement = 'SELECT [' + pk + '] FROM [' + tableName + '] ' + criteria;
-      mssql.connect(marshalConfig(connections[connection].config), function __UPDATE__(err) {
+      adapter.connectConnection(connection, function __UPDATE__(err) {
         if (err) {
           console.error(err);
           return cb(err);
         }
 
-        var request = new mssql.Request();
+        var request = new mssql.Request(connections[connection].mssqlConnection);
         request.query(statement, function(err, recordset) {
           if (err) return cb(err);
           //console.log('updating pks', recordset);
@@ -395,7 +408,7 @@ module.exports = (function () {
       var tableName = collection;
       var statement = 'DELETE FROM [' + tableName + '] ';
       statement += sql.serializeOptions(collection, options);
-      mssql.connect(marshalConfig(connections[connection].config), function __DELETE__(err) {
+      adapter.connectConnection(connection, function __DELETE__(err) {
         if (err) {
           console.error(err);
           return cb(err);
@@ -403,7 +416,7 @@ module.exports = (function () {
 
         adapter.find(connection, collection, options, function (err, records){
           if (err) return cb(err);
-          var request = new mssql.Request();
+          var request = new mssql.Request(connections[connection].mssqlConnection);
 
           request.query(statement, function(err, emptyDeleteRecordSet) {
             if (err) return cb(err);


### PR DESCRIPTION
The existing code manages multiple waterline connections just fine, but it relies on using the mssql driver connection as a singleton.  This creates problems where:

Product.find().exec(...); //adapter1
User.find().exec(...) //adapter2

The sequence of events looks like: 
* Product connects mssql to adapter1
* User connects mssql to adapter2
* Product find request fires against mssql which is now erroneously connected to adapter2
* User find request fires against mssql connected to adapter2

This PR changes it so there will always be one mssql connection object per waterline connection. Tests are still passing.

Questions:
* Is the mssql driver connection pool stuff *really* being utilized?
* Should the connections be closed at some point?

