### PR TITLE
avoiding " IN () " error if criterion-array value is empty

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -9,13 +9,13 @@ var sql = {
 	},
 
 	escape: function(val, stringifyObjects, timeZone) {
-  
+
 		if (val === undefined || val === null) {
 			return 'NULL';
 		}
 
 		switch (typeof val) {
-			case 'boolean': return (val) ? '1' : '0'; 
+			case 'boolean': return (val) ? '1' : '0';
 			case 'number': return val + '';
 		}
 
@@ -35,7 +35,7 @@ var sql = {
 
 	normalizeSchema: function (schema) {
 		return _.reduce(schema, function(memo, field) {
-			
+
 			// Marshal mssql DESCRIBE to waterline collection semantics
 			var attrName = field.ColumnName;
 			var type = field.TypeName;
@@ -207,7 +207,7 @@ var sql = {
 
 	// Recursively parse a predicate calculus and build a SQL query
 	predicate: function(collectionName, criterion, key, parentKey) {
-	
+
 		var queryPart = '';
 
 		if (parentKey) {
@@ -228,8 +228,9 @@ var sql = {
 
 		// IN
 		else if (_.isArray(criterion)) {
-			queryPart = sql.prepareAttribute(collectionName, null, key) + " IN (" + sql.values(collectionName, criterion, key) + ")";
-      return queryPart;
+			values = sql.values(collectionName, criterion, key) || 'NULL';
+			queryPart = sql.prepareAttribute(collectionName, null, key) + " IN (" + values + ")";
+			return queryPart;
 		}
 
 		// LIKE
@@ -304,13 +305,13 @@ var sql = {
 		}
 
 		return queryPart;
-	},	
+	},
 
 	build: function(collectionName, collection, fn, separator, keyOverride, parentKey) {
 
 		separator = separator || ', ';
 		var $sql = '';
-		
+
 		_.each(collection, function(value, key) {
 			$sql += fn(collectionName, value, keyOverride || key, parentKey);
 


### PR DESCRIPTION
When (0,n) <-> (0,n) models refer to 0 link, it makes a " WHERE id IN () " request, and SQLserver throw error because of the "()". 
Fixed that with "NULL" if sql.values(...) returns empty string. (Line 231-233, others are deletion of useless spaces) 