### PR TITLE
fix issue with string literal values not prepended with 'N' before th…

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -29,7 +29,9 @@ var sql = {
 				default: return " ";
 			}
 		});
-
+		if (/[^\u0000-\u00ff]/.test(val)) {
+		  return "N'" + val + "'";
+		}
 		return "'" + val + "'";
 	},
 


### PR DESCRIPTION
…e delimeter, which is imperative for unicode values

for Issue #20 