### PR TITLE
Changed String type from Nvarchar(max) to (255) to allow unique attribute

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -331,7 +331,7 @@ function sqlTypeCast(type) {
 
 	switch (type) {
     case 'binary':
-		case 'string': return 'NVARCHAR(max)';
+		case 'string': return 'NVARCHAR(255)';
 
 		case 'array':
 		case 'json':


### PR DESCRIPTION
fixed unique string for model, mssql cannot create unique constrains with Nvarchar(max)