### PR TITLE
Use callback with connection.connect() instead of promise

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -119,8 +119,7 @@ module.exports = (function () {
 
       if (isPersistent && (!connections[connection].mssqlConnection || !connections[connection].mssqlConnection.connected)) {
         connections[connection].mssqlConnection = new mssql.Connection(marshalConfig(connections[connection].config));
-        connections[connection].mssqlConnection.connect()
-          .then(cb);
+        connections[connection].mssqlConnection.connect(cb);
       }
       else if (!isPersistent && (!connections[connection].mssqlConnection || !connections[connection].mssqlConnection[uniqId] || !connections[connection].mssqlConnection[uniqId].connected)) {
         if (!connections[connection].mssqlConnection) {
@@ -128,8 +127,7 @@ module.exports = (function () {
         }
 
         connections[connection].mssqlConnection[uniqId] = new mssql.Connection(marshalConfig(connections[connection].config));
-        connections[connection].mssqlConnection[uniqId].connect()
-          .then(function(err) {
+        connections[connection].mssqlConnection[uniqId].connect(function(err) {
             cb(err, uniqId);
           });
       }


### PR DESCRIPTION
The code currently uses a promise with connection.connect, but only passes one of the two necessary functions (success and error). When an error occurs, there's no way for it to surface because no error function was given. I've updated this to simply use a callback