### PR TITLE
Add select options to filter down columns that are passed back

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,68 +69,80 @@ utils.buildSelectStatement = function(criteria, table) {
 
   var query = 'SELECT ';
 
-  if(criteria.groupBy || criteria.sum || criteria.average || criteria.min || criteria.max) {
+  if(criteria.select || criteria.groupBy || criteria.sum || criteria.average || criteria.min || criteria.max) {
 
-    // Append groupBy columns to select statement
-    if(criteria.groupBy) {
-      if(criteria.groupBy instanceof Array) {
-        criteria.groupBy.forEach(function(opt){
-          query += '[' + opt + '], ';
-        });
-
+    // Select only certain columns
+    if(criteria.select){
+      if(criteria.select instanceof Array) {
+          criteria.select.forEach(function(opt){
+            query += '[' + opt + '], ';
+          });
       } else {
-        query += '[' + criteria.groupBy + '], ';
+        query += '[' + criteria.select + '], ';
+      }
+    } else {
+      // Other select functions
+
+      // Append groupBy columns to select statement
+      if(criteria.groupBy) {
+        if(criteria.groupBy instanceof Array) {
+          criteria.groupBy.forEach(function(opt){
+            query += '[' + opt + '], ';
+          });
+
+        } else {
+          query += '[' + criteria.groupBy + '], ';
+        }
+      }
+
+      // Handle SUM
+      if (criteria.sum) {
+        if(criteria.sum instanceof Array) {
+          criteria.sum.forEach(function(opt){
+            query += 'SUM([' + opt + ']) AS [' + opt + '], ';
+          });
+
+        } else {
+          query += 'SUM([' + criteria.sum + ']) AS [' + criteria.sum + '], ';
+        }
+      }
+
+      // Handle AVG (casting to float to fix percision with trailing zeros)
+      if (criteria.average) {
+        if(criteria.average instanceof Array) {
+          criteria.average.forEach(function(opt){
+            query += 'AVG(CAST([' + opt + '] AS FLOAT)) AS [' + opt + '], ';
+          });
+
+        } else {
+          query += 'AVG(CAST([' + criteria.average + '] AS FLOAT)) AS [' + criteria.average + '], ';
+        }
+      }
+
+      // Handle MAX
+      if (criteria.max) {
+        if(criteria.max instanceof Array) {
+          criteria.max.forEach(function(opt){
+            query += 'MAX([' + opt + ']) AS [' + opt + '], ';
+          });
+
+        } else {
+          query += 'MAX([' + criteria.max + ']) AS [' + criteria.max + '], ';
+        }
+      }
+
+      // Handle MIN
+      if (criteria.min) {
+        if(criteria.min instanceof Array) {
+          criteria.min.forEach(function(opt){
+            query += 'MIN([' + opt + ']) AS [' + opt + '], ';
+          });
+
+        } else {
+          query += 'MIN([' + criteria.min + ']) AS [' + criteria.min + '], ';
+        }
       }
     }
-
-    // Handle SUM
-    if (criteria.sum) {
-      if(criteria.sum instanceof Array) {
-        criteria.sum.forEach(function(opt){
-          query += 'SUM([' + opt + ']) AS [' + opt + '], ';
-        });
-
-      } else {
-        query += 'SUM([' + criteria.sum + ']) AS [' + criteria.sum + '], ';
-      }
-    }
-
-    // Handle AVG (casting to float to fix percision with trailing zeros)
-    if (criteria.average) {
-      if(criteria.average instanceof Array) {
-        criteria.average.forEach(function(opt){
-          query += 'AVG(CAST([' + opt + '] AS FLOAT)) AS [' + opt + '], ';
-        });
-
-      } else {
-        query += 'AVG(CAST([' + criteria.average + '] AS FLOAT)) AS [' + criteria.average + '], ';
-      }
-    }
-
-    // Handle MAX
-    if (criteria.max) {
-      if(criteria.max instanceof Array) {
-        criteria.max.forEach(function(opt){
-          query += 'MAX([' + opt + ']) AS [' + opt + '], ';
-        });
-
-      } else {
-        query += 'MAX([' + criteria.max + ']) AS [' + criteria.max + '], ';
-      }
-    }
-
-    // Handle MIN
-    if (criteria.min) {
-      if(criteria.min instanceof Array) {
-        criteria.min.forEach(function(opt){
-          query += 'MIN([' + opt + ']) AS [' + opt + '], ';
-        });
-
-      } else {
-        query += 'MIN([' + criteria.min + ']) AS [' + criteria.min + '], ';
-      }
-    }
-
     // trim trailing comma
     query = query.slice(0, -2) + ' ';
 


### PR DESCRIPTION
Hi!
Great plugin. I've been using it with great ease and now that I'm looking at optimizing my app I've been looking at scaling down the data that is retrieved from the DB on typically select queries.

Looking through the code I couldn't find a way to do it so I added a little bit of logic that will accept select as a criteria. It can be used to filter the columns that SQL returns.

For example

```javascript
  Plugins.find({
    select: ['name','author']
  })
  .where({
    framework: 'sails.js'
  })
  .then(function(results){
    if (results) {
      results.forEach(function(plugin)){
        console.log(plugin)
      }      
    } else {
      console.log('No plugins found')
   }
  })
```