### PR TITLE
Fix insert for tables with GUID PKs

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -382,8 +382,11 @@ module.exports = (function () {
       Object.keys(values).forEach(function(key) {
         values[key] = utils.prepareValue(values[key]);
         if (pk == key && pk == 'id') {
-          identityInsert = true;
-          //console.log(pk, '==', key);
+          var type = connections[connection].collections[collection].definition['id'].type;
+          if(type === 'number'){
+            identityInsert = true;
+            //console.log(pk, '==', key);
+          }
         }
       });
       var schemaName = getSchemaName(connection, collection);


### PR DESCRIPTION
Fix issue were insert would break if the PK was a GUID due to the adapter adding an SET IDENTITY_INSERT clause which should only be used with integer PKs.