### PR TITLE
Add count() method to the adapter

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -341,6 +341,49 @@ module.exports = (function () {
 
       });
     },
+
+    // COUNT method
+    count: function(connection, collection, options, cb) {
+      // Check if this is an aggregate query and that there is something to return
+      if (options.groupBy || options.sum || options.average || options.min || options.max) {
+        if (!options.sum && !options.average && !options.min && !options.max) {
+          return cb(new Error('Cannot groupBy without a calculation'));
+        }
+      }
+
+      options.__primaryKey__ = adapter.getPrimaryKey(connection, collection);
+
+      var criteria = sql.serializeOptions(collection, options);
+      var statement = 'SELECT COUNT(*) AS count FROM ['+ collection +'] ' + criteria;
+
+      adapter.connectConnection(connection, function __COUNT__(err, uniqId) {
+        if (err) {
+          console.error(err);
+          return cb(err);
+        }
+
+        uniqId = uniqId || false;
+        var mssqlConnect;
+        if (!uniqId) {
+          mssqlConnect = connections[connection].mssqlConnection;
+        }
+        else {
+          mssqlConnect = connections[connection].mssqlConnection[uniqId];
+        }
+
+        var request = new mssql.Request(mssqlConnect);
+
+        request.query(statement, function(err, recordset) {
+          if (err) return cb(err);
+          if (!connections[connection].persistent) {
+            mssqlConnect && mssqlConnect.close();
+          }
+
+          cb(null, recordset[0].count);
+        });
+      });      
+    },
+
     // Raw Query Interface
     query: function (connection, collection, query, data, cb) {
       if (_.isFunction(data)) {


### PR DESCRIPTION
I added a count method to the adapter because the performance problems with the default count method that waterline implements.

It's a quick fix, just a copy of the find method but with a different statement, works wonderful and the performance is superb.