### PR TITLE
Adapting for sails version 1.x.x

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -45,6 +45,8 @@ module.exports = (function () {
 
   var adapter = {
 
+    identity: 'sails-sqlserver-sailsv1',
+    adapterApiVersion: 1,
     // Set to true if this adapter supports (or requires) things like data
     // types, validations, keys, etc. If true, the schema for models using this
     // adapter will be automatically synced when the server starts. Not
@@ -92,7 +94,7 @@ module.exports = (function () {
      * @param  {Function} cb         [description]
      * @return {[type]}              [description]
      */
-    registerConnection: function(connection, collections, cb) {
+    registerDatastore: function(connection, collections, cb) {
       if (!connection.identity) return cb(new Error('Connection is missing an identity.'));
       if (connections[connection.identity]) return cb(new Error('Connection is already registered.'));
 


### PR DESCRIPTION
Hi There,

As of now, I'm working with the latest version of **sailsjs (1.0.2)**, the **sails-hook-orm** reject me lift up the project
It's required an **'identity'** and **'adapterApiVersion'** for the **adapter** object.
Could you please kindly review this Pull request?

Best,
Trong
